### PR TITLE
Launcher exits when server is not longer running

### DIFF
--- a/lib/upstart_unicorn_launcher.rb
+++ b/lib/upstart_unicorn_launcher.rb
@@ -17,9 +17,8 @@ class UpstartUnicornLauncher
     quit_server_on :QUIT, :INT, :TERM
     forward_to_server :USR1, :USR2, :WINCH, :TTIN, :TTOU
     start_server
-    loop do
-      sleep 1
-    end
+
+    wait_for_server_to_quit
   end
 
   private
@@ -55,6 +54,12 @@ class UpstartUnicornLauncher
 
   def wait_until_server_quits
     wait_for_with_timeout { !running? }
+  end
+
+  def wait_for_server_to_quit
+    until !running?
+      sleep 1
+    end
   end
 
   def restart_server

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,12 @@ module SpecHelper
     Process.kill signal, @launcher_pid
   end
 
+  def launcher_running?
+    !!Process.getpgid(@launcher_pid)
+  rescue Errno::ESRCH
+    false
+  end
+
   def kill_launcher
     puts "Killing #{@launcher_pid}"
     Process.kill "QUIT", @launcher_pid

--- a/spec/templates/test/unicorn.rb
+++ b/spec/templates/test/unicorn.rb
@@ -1,1 +1,1 @@
-pid "/Users/tomw/Projects/tools/upstart-unicorn-launcher/spec/templates/test/unicorn.pid"
+pid "spec/templates/test/unicorn.pid"

--- a/spec/upstart_integration_spec.rb
+++ b/spec/upstart_integration_spec.rb
@@ -42,7 +42,7 @@ describe 'Upstart integration' do
     start_launcher
     original_response = perform_request.body_str
     send_to_launcher 'HUP'
-    sleep 1
+    sleep 5
     expect(perform_request.body_str).to_not eql(original_response)
   end
 
@@ -55,5 +55,12 @@ describe 'Upstart integration' do
       expect {responses << perform_request.body_str}.to_not raise_error
     end
     expect(responses.uniq.size).to eql(2)
+  end
+
+  it 'stops running when server quits' do
+    start_launcher
+    send_to_launcher 'QUIT'
+    sleep 2
+    expect(launcher_running?).to be(false)
   end
 end


### PR DESCRIPTION
Upstart can now respawn if the processes launched by upstart-unicorn-launcher exited.
